### PR TITLE
Call makePartial in Operations > Mocking Jobs example

### DIFF
--- a/content/operations/_index.md
+++ b/content/operations/_index.md
@@ -314,8 +314,9 @@ class NotifySubscribersOperationTest extends TestCase
             ->has(Subscriber::factory($subscribers));
             ->create();
 
-        // create operation mock instance
-        $mOp = Mockery::mock(NotifySubscribersOperation::class, [$author->id]);
+        // create operation partial mock instance
+        $mOp = Mockery::mock(NotifySubscribersOperation::class, [$author->id])
+            ->makePartial();
 
         // set expectations to jobs that need to be skipped
         $mOp->shouldReceive('run')


### PR DESCRIPTION
Even though the text under Operations > Mocking Jobs explains we should partially mock the operation, the example doesn't actually call `makePartial`, causing the test to fail.